### PR TITLE
Sessão expira após um tempo de inatividade

### DIFF
--- a/fouruc/settings.py
+++ b/fouruc/settings.py
@@ -59,7 +59,11 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'django_session_timeout.middleware.SessionTimeoutMiddleware',
 ]
+
+SESSION_EXPIRE_SECONDS = 30  # 3600 = 1 hour | 60 = 1 minute
+SESSION_EXPIRE_AFTER_LAST_ACTIVITY = True
 
 ROOT_URLCONF = 'fouruc.urls'
 

--- a/fouruc/settings.py
+++ b/fouruc/settings.py
@@ -62,7 +62,7 @@ MIDDLEWARE = [
     'django_session_timeout.middleware.SessionTimeoutMiddleware',
 ]
 
-SESSION_EXPIRE_SECONDS = 30  # 3600 = 1 hour | 60 = 1 minute
+SESSION_EXPIRE_SECONDS = 3600  # 3600 = 1 hour | 60 = 1 minute
 SESSION_EXPIRE_AFTER_LAST_ACTIVITY = True
 
 ROOT_URLCONF = 'fouruc.urls'

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ colorama==0.4.4
 dj-database-url==0.5.0
 Django==3.2.2
 django-s3-folder-storage==0.5
+django-session-timeout==0.1.0
 django-storages==1.11.1
 gunicorn==20.1.0
 idna==2.10


### PR DESCRIPTION
- Instalada a lib `django-session-timeout`
- Adicionado no [`settings.py`](https://github.com/Alfareiza/4uc-manager-silver/blob/main/fouruc/settings.py) o seguinte:
```
MIDDLEWARE_CLASSES = [
    # ...
    'django.contrib.sessions.middleware.SessionMiddleware', # Se esse middleware já se encontra, então não deve estar repetido
    'django_session_timeout.middleware.SessionTimeoutMiddleware',
    # ...
]

SESSION_EXPIRE_SECONDS = 3600  # 1 hour
SESSION_EXPIRE_AFTER_LAST_ACTIVITY = True
```
----
Documentação da lib django-session-timeout
https://pypi.org/project/django-session-timeout/